### PR TITLE
IT-2623 Update release-package.yml workflow to use Trusted publishing

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -1,5 +1,9 @@
 name: Release NPM package
 
+permissions:
+  id-token: write  # Required for NPM trusted publishing
+  contents: read
+
 on:
   release:
     types: [ published ]
@@ -11,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: '23.10'
           registry-url: 'https://registry.npmjs.org'
@@ -33,8 +37,6 @@ jobs:
 
       - name: Publish package to NPM
         run: yarn workspace @maptiler/upload-js npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.npm_token }}
 
       - name: Disable Corepack
         run: corepack disable


### PR DESCRIPTION
IT-2623

## Objective
Replace NPM_TOKEN by NPM Trusted publishing, see: https://maptiler.atlassian.net/wiki/spaces/MAPTILER/pages/3761274898/Public+NPM+packages

## Description
Workflow release-package.yml updated:
- permissions required for OIDC added
- NPM_TOKEN environment variable removed
- actions version updated

GitHub Actions connection to NPMJS registry is already setup.

## Acceptance
ACTION REQUIRED:
Please review, merge and test. In case of any issues, contact Infrastructure team.
NPM_TOKEN will expire Aug 24, 2026, after this date old authentication will no longer work.